### PR TITLE
ti_redflag: treat daily-diff 404 as zero events, bump to v1.2.1

### DIFF
--- a/ti_redflag/changelog.yml
+++ b/ti_redflag/changelog.yml
@@ -1,4 +1,10 @@
 # newer versions go on top
+- version: "1.2.1"
+  changes:
+    - description: >-
+        Fix the daily diff feed erroring every poll before the vendor publishes anything for the current day. Confirmed the vendor does not pre-create a day's file at midnight -- it only appears once the first domain of that day is added, so a 404 on today's dated file is normal and now treated as zero new events instead of an error.
+      type: bugfix
+      link: https://github.com/fred-maussion/community_elastic-custom-integrations/issues/73
 - version: "1.2.0"
   changes:
     - description: >-

--- a/ti_redflag/data_stream/domains/_dev/test/policy/test-default-policy.expected
+++ b/ti_redflag/data_stream/domains/_dev/test/policy/test-default-policy.expected
@@ -43,6 +43,8 @@ inputs:
                         .split('\n')
                         .filter(line, line != '' && !line.startsWith('#'))
                         .map(domain, {"message": domain + "|daily_diff"})
+                    }) : (resp.StatusCode == 404) ? dyn({
+                      "events": []
                     }) : dyn({
                       "events": {
                         "error": {

--- a/ti_redflag/data_stream/domains/agent/stream/cel.yml.hbs
+++ b/ti_redflag/data_stream/domains/agent/stream/cel.yml.hbs
@@ -40,6 +40,8 @@ program: |-
               .split('\n')
               .filter(line, line != '' && !line.startsWith('#'))
               .map(domain, {"message": domain + "|daily_diff"})
+          }) : (resp.StatusCode == 404) ? dyn({
+            "events": []
           }) : dyn({
             "events": {
               "error": {

--- a/ti_redflag/data_stream/domains/manifest.yml
+++ b/ti_redflag/data_stream/domains/manifest.yml
@@ -31,7 +31,9 @@ streams:
         title: "Daily Feed Base URL"
         description: |-
           Base URL for the Red Flag Domains daily diff feed. Today's date (formatted YYYY-MM-DD)
-          and the .txt suffix are appended automatically.
+          and the .txt suffix are appended automatically. The vendor only creates today's file
+          once the first domain of the day is published, so a 404 early in the day is normal and
+          treated as zero new domains rather than an error.
         required: true
         show_user: false
         secret: false

--- a/ti_redflag/manifest.yml
+++ b/ti_redflag/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 3.5.0
 name: ti_redflag
 title: "Red Flag Domains"
-version: 1.2.0
+version: 1.2.1
 source:
   license: "Apache-2.0"
 description: "Ingest threat intelligence indicators from red.flag.domains feeds with Elastic Agent."


### PR DESCRIPTION
## Summary

Fixes a real error surfaced on a live serverless deployment:

```
ti_redflag.domains: single event error object returned by evaluation: {"error":{"message":"Failed to download Red Flag Domains daily feed. Status code: 404"}}
```

Confirmed via a live check that the vendor does not pre-create a day's daily-diff file at midnight -- it only appears once the first domain of that day is published:

```
curl -s -o /dev/null -w "%{http_code}\n" https://dl.red.flag.domains/daily/2026-07-07.txt   # 404
curl -s -o /dev/null -w "%{http_code}\n" https://dl.red.flag.domains/daily/2026-07-06.txt   # 200
```

A 404 specifically on the daily-diff URL now resolves to zero events (a normal successful poll) instead of an error object. Any other non-200 status code still surfaces as a genuine error, unchanged.

Closes #73

## Test plan

- [x] Verified all three response paths (200 / 404 / other error) locally with `mito` before touching the real template
- [x] `elastic-package format` / `lint` / `check` -- all pass
- [x] `elastic-package test static/policy/asset/pipeline/system` -- all pass on a local Docker stack (policy fixture regenerated since the CEL program text changed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)